### PR TITLE
Always use __name__ to get loggers

### DIFF
--- a/cherryml/caching/_common.py
+++ b/cherryml/caching/_common.py
@@ -7,7 +7,7 @@ from typing import List
 
 
 def _init_logger():
-    logger = logging.getLogger("caching")
+    logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
     fmt_str = "[%(asctime)s] - %(name)s - %(levelname)s - %(message)s"
     formatter = logging.Formatter(fmt_str)
@@ -18,7 +18,7 @@ def _init_logger():
 
 
 _init_logger()
-logger = logging.getLogger("caching")
+logger = logging.getLogger(__name__)
 
 _CACHE_DIR = None
 _USE_HASH = True
@@ -39,7 +39,7 @@ def get_cache_dir():
 
 
 def set_log_level(log_level: int):
-    logger = logging.getLogger("caching")
+    logger = logging.getLogger(__name__)
     logger.setLevel(level=log_level)
 
 

--- a/cherryml/phylogeny_estimation/_phyml.py
+++ b/cherryml/phylogeny_estimation/_phyml.py
@@ -19,7 +19,7 @@ from ._common import name_internal_nodes, translate_tree
 
 
 def _init_logger():
-    logger = logging.getLogger("phylogeny_estimation.phyml")
+    logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
     fmt_str = "[%(asctime)s] - %(name)s - %(levelname)s - %(message)s"
     formatter = logging.Formatter(fmt_str)
@@ -55,7 +55,7 @@ def _install_phyml() -> str:
     """
     if _phyml_is_installed_on_system():
         return "phyml"
-    logger = logging.getLogger("phylo_correction.phyml")
+    logger = logging.getLogger(__name__)
     logger.info("Checking for PhyML ...")
     dir_path = os.path.dirname(os.path.realpath(__file__))
     phyml_path = os.path.join(dir_path, "phyml_github")
@@ -287,7 +287,7 @@ def phyml(
     output_site_rates_dir: Optional[str] = None,
     output_likelihood_dir: Optional[str] = None,
 ):
-    logger = logging.getLogger("phylogeny_estimation.phyml")
+    logger = logging.getLogger(__name__)
 
     if not os.path.exists(output_tree_dir):
         os.makedirs(output_tree_dir)


### PR DESCRIPTION
Makes logging clearer, especially when using cherryml from within another package.