### PR TITLE
Improve setup.py

### DIFF
--- a/cherryml/__init__.py
+++ b/cherryml/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.0.5"
+__version__ = "v0.0.6"
 
 from cherryml._cherryml_public_api import cherryml_public_api
 from cherryml.counting import count_co_transitions, count_transitions

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
 from setuptools import setup, find_packages
 
 
-# Import version
-__builtins__.__CHERRYML_SETUP__ = True
-from cherryml import __version__ as version
+def get_version_from_init(init_path='cherryml/__init__.py'):
+    with open(init_path, 'r') as f:
+        for line in f:
+            if line.startswith('__version__'):
+                return eval(line.split('=')[-1])
 
+
+version = get_version_from_init()
 
 setup(
     name='cherryml',


### PR DESCRIPTION
A package's setup.py shouldn't rely on imports from the package itself (especially when those imports depend on other packages) to get metadata or other information. This PR should fix this.