### PR TITLE
Allow retaining full-length proteins in trRosetta dataset

### DIFF
--- a/cherryml/__init__.py
+++ b/cherryml/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.0.7"
+__version__ = "v0.0.8"
 
 from cherryml._cherryml_public_api import cherryml_public_api
 from cherryml.counting import count_co_transitions, count_transitions

--- a/cherryml/__init__.py
+++ b/cherryml/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.0.6"
+__version__ = "v0.0.7"
 
 from cherryml._cherryml_public_api import cherryml_public_api
 from cherryml.counting import count_co_transitions, count_transitions

--- a/cherryml/caching/__init__.py
+++ b/cherryml/caching/__init__.py
@@ -9,15 +9,7 @@ applications.
 """
 from ._cached import cached
 from ._cached_computation import cached_computation
-from ._cached_parallel_computation import (
-    cached_parallel_computation,
-    secure_parallel_output,
-)
-from ._common import (
-    set_cache_dir,
-    set_dir_levels,
-    set_hash_len,
-    set_log_level,
-    set_read_only,
-    set_use_hash,
-)
+from ._cached_parallel_computation import (cached_parallel_computation,
+                                           secure_parallel_output)
+from ._common import (set_cache_dir, set_dir_levels, set_hash_len,
+                      set_log_level, set_read_only, set_use_hash)

--- a/cherryml/caching/_cached.py
+++ b/cherryml/caching/_cached.py
@@ -5,14 +5,8 @@ from functools import wraps
 from inspect import signature
 from typing import List, Optional
 
-from ._common import (
-    CacheUsageError,
-    _get_mode,
-    _hash_all,
-    get_cache_dir,
-    get_read_only,
-    get_use_hash,
-)
+from ._common import (CacheUsageError, _get_mode, _hash_all, get_cache_dir,
+                      get_read_only, get_use_hash)
 
 logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 

--- a/cherryml/io/_msa.py
+++ b/cherryml/io/_msa.py
@@ -69,10 +69,6 @@ def read_msa(
         seq_name = lines[2 * i][1:]
         seq = lines[2 * i + 1]
         msa[seq_name] = seq
-    if len(set([len(seq) for seq in msa.values()])) != 1:
-        raise Exception(
-            f"MSA at {msa_path}: All sequences should have the same length."
-        )
     return msa
 
 


### PR DESCRIPTION
Allow retaining full-length proteins in trRosetta dataset & update caching module to latest version such that we can use exclude_args_if_default in cached_parallel_computation