### PR TITLE
Reduce io in ratelearner

### DIFF
--- a/cherryml/__init__.py
+++ b/cherryml/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.0.8"
+__version__ = "v0.1.0"
 
 from cherryml._cherryml_public_api import cherryml_public_api
 from cherryml.counting import count_co_transitions, count_transitions

--- a/cherryml/estimation/_ratelearn/ratelearner.py
+++ b/cherryml/estimation/_ratelearn/ratelearner.py
@@ -79,7 +79,7 @@ class RateMatrixLearner:
         output_dir = self.output_dir
         initialization = self.initialization
 
-        if not skip_writing_to_output_dir:
+        if not self.skip_writing_to_output_dir:
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
 

--- a/cherryml/estimation/_ratelearn/ratelearner.py
+++ b/cherryml/estimation/_ratelearn/ratelearner.py
@@ -147,7 +147,7 @@ class RateMatrixLearner:
     def get_branch_to_mat(self):
         n_features = self.mats[0].shape[0]
         qtimes = torch.tensor(self.branches)
-        cmats = torch.tensor(self.mats)
+        cmats = torch.tensor(np.array(self.mats))
         quantized_data = TensorDataset(qtimes, cmats)
         return quantized_data, n_features
 


### PR DESCRIPTION
In some cases, it is desirable to avoid all I/O in the ratelearner to speed things up. This backwards-compatible PR enables this by exposing a `skip_writing_to_output_dir` argument. The ratelearner exposes a method `get_learnt_rate_matrix` to get the learnt rate matrix in this case.

This PR also addresses a warning in ratelearner by replacing `cmats = torch.tensor(self.mats)` by `cmats = torch.tensor(np.array(self.mats))`. Pytorch was complaining that creating a tensor from a list of numpy arrays was slow, suggesting to use `torch.tensor(np.array(...))` instead.