### PR TITLE
Relax assertions

### DIFF
--- a/cherryml/__init__.py
+++ b/cherryml/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.1.0"
+__version__ = "v0.1.1"
 
 from cherryml._cherryml_public_api import cherryml_public_api
 from cherryml.counting import count_co_transitions, count_transitions


### PR DESCRIPTION
np.testing checks to 7 decimal digits, which is too much and leads to false positives.