### PR TITLE
Update _rate_matrix.py

### DIFF
--- a/cherryml/io/_rate_matrix.py
+++ b/cherryml/io/_rate_matrix.py
@@ -57,7 +57,7 @@ def write_rate_matrix(
 def read_rate_matrix(rate_matrix_path: str) -> pd.DataFrame:
     res = pd.read_csv(
         rate_matrix_path,
-        delim_whitespace=True,
+        sep="\s+",
         index_col=0,
         keep_default_na=False,
         na_values=["_"],


### PR DESCRIPTION
This warning comes up every time this function is called:

FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\s+'`` instead